### PR TITLE
remove ponder

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 ### Tech Used
 
-[Ponder](https://ponder.sh/)
+[Ponder](https://ponder.sh/) // Deprecated
 
 [Next.js](https://nextjs.org/)
 

--- a/frontend/src/app/nft/[id]/image/route.tsx
+++ b/frontend/src/app/nft/[id]/image/route.tsx
@@ -83,7 +83,7 @@ async function generateImage(profile: Profile): Promise<ImageResponse> {
             textShadow: '2px 2px 12px rgba(0, 0, 0, 0.1)',
           }}
         >
-          <span>{profile.label}.</span>
+          <span>{profile.name}.</span>
 
           <span
             style={{

--- a/frontend/src/app/nft/[id]/image/route.tsx
+++ b/frontend/src/app/nft/[id]/image/route.tsx
@@ -1,4 +1,4 @@
-import { Profile, getNameByTokenId } from '@/lib/ponder'
+import { Profile } from '@/lib/ponder'
 import { ImageResponse } from '@vercel/og'
 import { NextRequest, NextResponse } from 'next/server'
 import z from 'zod'
@@ -26,7 +26,17 @@ export async function GET(
 
   const { id } = safeParse.data
 
-  const profile = await getNameByTokenId(id)
+  const queryParams = new URLSearchParams({
+    'cache-bust': Date.now().toString(),
+  })
+  const nameJson = await fetch(
+    `https://namestone.xyz/api/public_v1/get-name-by-token-id?domain=teamnick.eth&token_id=${id}&${queryParams.toString()}`,
+    { method: 'GET' }
+  )
+
+  let profile = null
+  if (nameJson.status === 200) profile = (await nameJson.json()) as any
+
   const image = await generateImage(profile)
   return image
 }

--- a/frontend/src/app/nft/[id]/route.ts
+++ b/frontend/src/app/nft/[id]/route.ts
@@ -1,4 +1,3 @@
-import { getNameByTokenId } from '@/lib/ponder'
 import { NextRequest, NextResponse } from 'next/server'
 import z from 'zod'
 
@@ -23,7 +22,16 @@ export async function GET(
 
   const { id } = safeParse.data
 
-  const profile = await getNameByTokenId(id)
+  const queryParams = new URLSearchParams({
+    'cache-bust': Date.now().toString(),
+  })
+  const nameJson = await fetch(
+    `https://namestone.xyz/api/public_v1/get-name-by-token-id?domain=teamnick.eth&token_id=${id}&${queryParams.toString()}`,
+    { method: 'GET' }
+  )
+
+  let profile = null
+  if (nameJson.status === 200) profile = (await nameJson.json()) as any
 
   if (!profile) {
     return NextResponse.json({ error: 'Invalid token id' }, { status: 404 })

--- a/frontend/src/app/records/page.tsx
+++ b/frontend/src/app/records/page.tsx
@@ -8,7 +8,6 @@ import {
   useWaitForTransaction,
 } from 'wagmi'
 import React, { useState, useEffect } from 'react'
-import { usePonder } from '@/hooks/usePonder'
 import {
   Avatar,
   Button,
@@ -19,7 +18,7 @@ import {
   RecordItem,
   Spinner,
 } from '@ensdomains/thorin'
-import { Profile2 } from '@/lib/ponder'
+import { NamestoneProfile } from '@/lib/ponder'
 import NavBar from '../components/NavBar'
 import { l2Registry } from '@/lib/l2-registry'
 import { start } from 'repl'
@@ -47,7 +46,8 @@ export default function Records() {
 function DisplayRecords() {
   const { address } = useAccount()
   const [selectedName, setSelectedName] = useState<string | null>(null)
-  const [selectedProfile, setSelectedProfile] = useState<Profile2 | null>(null)
+  const [selectedProfile, setSelectedProfile] =
+    useState<NamestoneProfile | null>(null)
   const [nameList, setNameList] = useState<Profile[]>([])
 
   async function fetchUserRecords() {
@@ -151,7 +151,7 @@ function UpdateRecords({
   selectedProfile,
   refetchNames,
 }: {
-  selectedProfile: Profile2 | undefined
+  selectedProfile: NamestoneProfile | undefined
   refetchNames: () => void
 }) {
   const { address } = useAccount()

--- a/frontend/src/lib/ponder.ts
+++ b/frontend/src/lib/ponder.ts
@@ -15,7 +15,7 @@ export type Profile = {
   address: string
   registeredAt: string
 }
-export type Profile2 = {
+export type NamestoneProfile = {
   tokenId: string
   name: string
   label: string

--- a/frontend/src/lib/ponder.ts
+++ b/frontend/src/lib/ponder.ts
@@ -15,6 +15,17 @@ export type Profile = {
   address: string
   registeredAt: string
 }
+export type Profile2 = {
+  tokenId: string
+  name: string
+  label: string
+  owner: string
+  textRecords: {
+    avatar: string
+  }
+  address: string
+  registeredAt: string
+}
 
 export const ponderUrl = 'https://teamnick-production.up.railway.app'
 


### PR DESCRIPTION
This pr removes all reliance on a running ponder instance in a quick and dirty way. once you merge it you can shut off your ponder instance.

It still relies on some of the typing definitions (Profile and Profile2)  in the ponder utility file on the frontend. If I wanted to make it better I'd clean up that file and rename it utilities or something similar